### PR TITLE
Project 2: Add solution

### DIFF
--- a/project2/main.cpp
+++ b/project2/main.cpp
@@ -1,17 +1,415 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
-#include "extendedbinomialtree.hpp"
+/*!
+ Copyright (C) 2005, 2006, 2007, 2009 StatPro Italia srl
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include <ql/qldefines.hpp>
+#ifdef BOOST_MSVC
+#  include <ql/auto_link.hpp>
+#endif
+#include <ql/instruments/vanillaoption.hpp>
 #include <ql/pricingengines/vanilla/binomialengine.hpp>
-#include <ql/experimental/lattices/extendedbinomialtree.hpp>
+#include <ql/pricingengines/vanilla/analyticeuropeanengine.hpp>
+#include <ql/pricingengines/vanilla/analytichestonengine.hpp>
+#include <ql/pricingengines/vanilla/baroneadesiwhaleyengine.hpp>
+#include <ql/pricingengines/vanilla/bjerksundstenslandengine.hpp>
+#include <ql/pricingengines/vanilla/batesengine.hpp>
+#include <ql/pricingengines/vanilla/integralengine.hpp>
+#include <ql/pricingengines/vanilla/fdeuropeanengine.hpp>
+#include <ql/pricingengines/vanilla/fdbermudanengine.hpp>
+#include <ql/pricingengines/vanilla/fdamericanengine.hpp>
+#include <ql/pricingengines/vanilla/mceuropeanengine.hpp>
+#include <ql/pricingengines/vanilla/mcamericanengine.hpp>
+#include <ql/time/calendars/target.hpp>
+#include <ql/utilities/dataformatters.hpp>
+
+#include <boost/timer.hpp>
 #include <iostream>
+#include <iomanip>
+
+#include <ql/experimental/lattices/extendedbinomialtree.hpp>
 
 using namespace QuantLib;
 
-int main() {
+#if defined(QL_ENABLE_SESSIONS)
+namespace QuantLib {
+
+    Integer sessionId() { return 0; }
+
+}
+#endif
+
+
+int main(int, char* []) {
 
     try {
 
-        // add your code here
+        boost::timer timer;
+        std::cout << std::endl;
 
+        // set up dates
+        Calendar calendar = TARGET();
+        Date todaysDate(15, May, 1998);
+        Date settlementDate(17, May, 1998);
+        Settings::instance().evaluationDate() = todaysDate;
+
+        // our options
+        Option::Type type(Option::Put);
+        Real underlying = 36;
+        Real strike = 40;
+        Spread dividendYield = 0.00;
+        Rate riskFreeRate = 0.06;
+        Volatility volatility = 0.20;
+        Date maturity(17, May, 1999);
+        DayCounter dayCounter = Actual365Fixed();
+
+        std::cout << "Option type = "  << type << std::endl;
+        std::cout << "Maturity = "        << maturity << std::endl;
+        std::cout << "Underlying price = "        << underlying << std::endl;
+        std::cout << "Strike = "                  << strike << std::endl;
+        std::cout << "Risk-free interest rate = " << io::rate(riskFreeRate)
+                  << std::endl;
+        std::cout << "Dividend yield = " << io::rate(dividendYield)
+                  << std::endl;
+        std::cout << "Volatility = " << io::volatility(volatility)
+                  << std::endl;
+        std::cout << std::endl;
+        std::string method;
+        std::cout << std::endl ;
+
+        // write column headings
+        Size widths[] = { 45, 14, 14, 14 };
+        std::cout << std::setw(widths[0]) << std::left << "Method"
+                  << std::setw(widths[1]) << std::left << "European"
+                  << std::setw(widths[2]) << std::left << "Bermudan"
+                  << std::setw(widths[3]) << std::left << "American"
+                  << std::endl;
+
+        std::vector<Date> exerciseDates;
+        for (Integer i=1; i<=4; i++)
+            exerciseDates.push_back(settlementDate + 3*i*Months);
+
+        ext::shared_ptr<Exercise> europeanExercise(
+                                         new EuropeanExercise(maturity));
+
+        ext::shared_ptr<Exercise> bermudanExercise(
+                                         new BermudanExercise(exerciseDates));
+
+        ext::shared_ptr<Exercise> americanExercise(
+                                         new AmericanExercise(settlementDate,
+                                                              maturity));
+
+        Handle<Quote> underlyingH(
+            ext::shared_ptr<Quote>(new SimpleQuote(underlying)));
+
+        // bootstrap the yield/dividend/vol curves
+        Handle<YieldTermStructure> flatTermStructure(
+            ext::shared_ptr<YieldTermStructure>(
+                new FlatForward(settlementDate, riskFreeRate, dayCounter)));
+        Handle<YieldTermStructure> flatDividendTS(
+            ext::shared_ptr<YieldTermStructure>(
+                new FlatForward(settlementDate, dividendYield, dayCounter)));
+        Handle<BlackVolTermStructure> flatVolTS(
+            ext::shared_ptr<BlackVolTermStructure>(
+                new BlackConstantVol(settlementDate, calendar, volatility,
+                                     dayCounter)));
+        ext::shared_ptr<StrikedTypePayoff> payoff(
+                                        new PlainVanillaPayoff(type, strike));
+        ext::shared_ptr<BlackScholesMertonProcess> bsmProcess(
+                 new BlackScholesMertonProcess(underlyingH, flatDividendTS,
+                                               flatTermStructure, flatVolTS));
+
+        // options
+        VanillaOption europeanOption(payoff, europeanExercise);
+        VanillaOption bermudanOption(payoff, bermudanExercise);
+        VanillaOption americanOption(payoff, americanExercise);
+
+        // Analytic formulas:
+
+        // Black-Scholes for European
+        // method = "Black-Scholes";
+        // europeanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
+        //                              new AnalyticEuropeanEngine(bsmProcess)));
+        // std::cout << std::setw(widths[0]) << std::left << method
+        //           << std::fixed
+        //           << std::setw(widths[1]) << std::left << europeanOption.NPV()
+        //           << std::setw(widths[2]) << std::left << "N/A"
+        //           << std::setw(widths[3]) << std::left << "N/A"
+        //           << std::endl;
+
+        // semi-analytic Heston for European
+        // method = "Heston semi-analytic";
+        // ext::shared_ptr<HestonProcess> hestonProcess(
+        //     new HestonProcess(flatTermStructure, flatDividendTS,
+        //                       underlyingH, volatility*volatility,
+        //                       1.0, volatility*volatility, 0.001, 0.0));
+        // ext::shared_ptr<HestonModel> hestonModel(
+        //                                       new HestonModel(hestonProcess));
+        // europeanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
+        //                              new AnalyticHestonEngine(hestonModel)));
+        // std::cout << std::setw(widths[0]) << std::left << method
+        //           << std::fixed
+        //           << std::setw(widths[1]) << std::left << europeanOption.NPV()
+        //           << std::setw(widths[2]) << std::left << "N/A"
+        //           << std::setw(widths[3]) << std::left << "N/A"
+        //           << std::endl;
+
+        // semi-analytic Bates for European
+        // method = "Bates semi-analytic";
+        // ext::shared_ptr<BatesProcess> batesProcess(
+        //     new BatesProcess(flatTermStructure, flatDividendTS,
+        //                      underlyingH, volatility*volatility,
+        //                      1.0, volatility*volatility, 0.001, 0.0,
+        //                      1e-14, 1e-14, 1e-14));
+        // ext::shared_ptr<BatesModel> batesModel(new BatesModel(batesProcess));
+        // europeanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
+        //                                         new BatesEngine(batesModel)));
+        // std::cout << std::setw(widths[0]) << std::left << method
+        //           << std::fixed
+        //           << std::setw(widths[1]) << std::left << europeanOption.NPV()
+        //           << std::setw(widths[2]) << std::left << "N/A"
+        //           << std::setw(widths[3]) << std::left << "N/A"
+        //           << std::endl;
+
+        // Barone-Adesi and Whaley approximation for American
+        // method = "Barone-Adesi/Whaley";
+        // americanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
+        //                new BaroneAdesiWhaleyApproximationEngine(bsmProcess)));
+        // std::cout << std::setw(widths[0]) << std::left << method
+        //           << std::fixed
+        //           << std::setw(widths[1]) << std::left << "N/A"
+        //           << std::setw(widths[2]) << std::left << "N/A"
+        //           << std::setw(widths[3]) << std::left << americanOption.NPV()
+        //           << std::endl;
+
+        // Bjerksund and Stensland approximation for American
+        // method = "Bjerksund/Stensland";
+        // americanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
+        //               new BjerksundStenslandApproximationEngine(bsmProcess)));
+        // std::cout << std::setw(widths[0]) << std::left << method
+        //           << std::fixed
+        //           << std::setw(widths[1]) << std::left << "N/A"
+        //           << std::setw(widths[2]) << std::left << "N/A"
+        //           << std::setw(widths[3]) << std::left << americanOption.NPV()
+        //           << std::endl;
+
+        // Integral
+        // method = "Integral";
+        // europeanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
+        //                                      new IntegralEngine(bsmProcess)));
+        // std::cout << std::setw(widths[0]) << std::left << method
+        //           << std::fixed
+        //           << std::setw(widths[1]) << std::left << europeanOption.NPV()
+        //           << std::setw(widths[2]) << std::left << "N/A"
+        //           << std::setw(widths[3]) << std::left << "N/A"
+        //           << std::endl;
+
+        // Finite differences
+        Size timeSteps = 5000;
+        // method = "Finite differences";
+        // europeanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
+        //          new FDEuropeanEngine<CrankNicolson>(bsmProcess,
+        //                                              timeSteps,timeSteps-1)));
+        // bermudanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
+        //          new FDBermudanEngine<CrankNicolson>(bsmProcess,
+        //                                              timeSteps,timeSteps-1)));
+        // americanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
+        //          new FDAmericanEngine<CrankNicolson>(bsmProcess,
+        //                                              timeSteps,timeSteps-1)));
+        // std::cout << std::setw(widths[0]) << std::left << method
+        //           << std::fixed
+        //           << std::setw(widths[1]) << std::left << europeanOption.NPV()
+        //           << std::setw(widths[2]) << std::left << bermudanOption.NPV()
+        //           << std::setw(widths[3]) << std::left << americanOption.NPV()
+        //           << std::endl;
+
+        // Binomial method: Jarrow-Rudd
+        method = "Extended Binomial Jarrow-Rudd";
+        europeanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
+                new BinomialVanillaEngine<ExtendedJarrowRudd>(bsmProcess,timeSteps)));
+        bermudanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
+                new BinomialVanillaEngine<ExtendedJarrowRudd>(bsmProcess,timeSteps)));
+        americanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
+                new BinomialVanillaEngine<ExtendedJarrowRudd>(bsmProcess,timeSteps)));
+        std::cout << std::setw(widths[0]) << std::left << method
+                  << std::fixed
+                  << std::setw(widths[1]) << std::left << europeanOption.NPV()
+                  << std::setw(widths[2]) << std::left << bermudanOption.NPV()
+                  << std::setw(widths[3]) << std::left << americanOption.NPV()
+                  << std::endl;
+        method = "Extended Binomial Cox-Ross-Rubinstein";
+        europeanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
+                      new BinomialVanillaEngine<ExtendedCoxRossRubinstein>(bsmProcess,
+                                                                   timeSteps)));
+        bermudanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
+                      new BinomialVanillaEngine<ExtendedCoxRossRubinstein>(bsmProcess,
+                                                                   timeSteps)));
+        americanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
+                      new BinomialVanillaEngine<ExtendedCoxRossRubinstein>(bsmProcess,
+                                                                   timeSteps)));
+        std::cout << std::setw(widths[0]) << std::left << method
+                  << std::fixed
+                  << std::setw(widths[1]) << std::left << europeanOption.NPV()
+                  << std::setw(widths[2]) << std::left << bermudanOption.NPV()
+                  << std::setw(widths[3]) << std::left << americanOption.NPV()
+                  << std::endl;
+
+        // Binomial method: Additive equiprobabilities
+        method = "Extended Additive equiprobabilities";
+        europeanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
+                new BinomialVanillaEngine<ExtendedAdditiveEQPBinomialTree>(bsmProcess,
+                                                                   timeSteps)));
+        bermudanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
+                new BinomialVanillaEngine<ExtendedAdditiveEQPBinomialTree>(bsmProcess,
+                                                                   timeSteps)));
+        americanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
+                new BinomialVanillaEngine<ExtendedAdditiveEQPBinomialTree>(bsmProcess,
+                                                                   timeSteps)));
+        std::cout << std::setw(widths[0]) << std::left << method
+                  << std::fixed
+                  << std::setw(widths[1]) << std::left << europeanOption.NPV()
+                  << std::setw(widths[2]) << std::left << bermudanOption.NPV()
+                  << std::setw(widths[3]) << std::left << americanOption.NPV()
+                  << std::endl;
+
+        // Binomial method: Binomial Trigeorgis
+        method = "Extended Binomial Trigeorgis";
+        europeanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
+                new BinomialVanillaEngine<ExtendedTrigeorgis>(bsmProcess,timeSteps)));
+        bermudanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
+                new BinomialVanillaEngine<ExtendedTrigeorgis>(bsmProcess,timeSteps)));
+        americanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
+                new BinomialVanillaEngine<ExtendedTrigeorgis>(bsmProcess,timeSteps)));
+        std::cout << std::setw(widths[0]) << std::left << method
+                  << std::fixed
+                  << std::setw(widths[1]) << std::left << europeanOption.NPV()
+                  << std::setw(widths[2]) << std::left << bermudanOption.NPV()
+                  << std::setw(widths[3]) << std::left << americanOption.NPV()
+                  << std::endl;
+
+        // Binomial method: Binomial Tian
+        method = "Extended Binomial Tian";
+        europeanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
+                      new BinomialVanillaEngine<ExtendedTian>(bsmProcess,timeSteps)));
+        bermudanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
+                      new BinomialVanillaEngine<ExtendedTian>(bsmProcess,timeSteps)));
+        americanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
+                      new BinomialVanillaEngine<ExtendedTian>(bsmProcess,timeSteps)));
+        std::cout << std::setw(widths[0]) << std::left << method
+                  << std::fixed
+                  << std::setw(widths[1]) << std::left << europeanOption.NPV()
+                  << std::setw(widths[2]) << std::left << bermudanOption.NPV()
+                  << std::setw(widths[3]) << std::left << americanOption.NPV()
+                  << std::endl;
+
+        // Binomial method: Binomial Leisen-Reimer
+        method = "Extended Binomial Leisen-Reimer";
+        europeanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
+              new BinomialVanillaEngine<ExtendedLeisenReimer>(bsmProcess,timeSteps)));
+        bermudanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
+              new BinomialVanillaEngine<ExtendedLeisenReimer>(bsmProcess,timeSteps)));
+        americanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
+              new BinomialVanillaEngine<ExtendedLeisenReimer>(bsmProcess,timeSteps)));
+        std::cout << std::setw(widths[0]) << std::left << method
+                  << std::fixed
+                  << std::setw(widths[1]) << std::left << europeanOption.NPV()
+                  << std::setw(widths[2]) << std::left << bermudanOption.NPV()
+                  << std::setw(widths[3]) << std::left << americanOption.NPV()
+                  << std::endl;
+
+        // Binomial method: Binomial Joshi
+        method = "Extended Binomial Joshi";
+        europeanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
+                    new BinomialVanillaEngine<ExtendedJoshi4>(bsmProcess,timeSteps)));
+        bermudanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
+                    new BinomialVanillaEngine<ExtendedJoshi4>(bsmProcess,timeSteps)));
+        americanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
+                    new BinomialVanillaEngine<ExtendedJoshi4>(bsmProcess,timeSteps)));
+        std::cout << std::setw(widths[0]) << std::left << method
+                  << std::fixed
+                  << std::setw(widths[1]) << std::left << europeanOption.NPV()
+                  << std::setw(widths[2]) << std::left << bermudanOption.NPV()
+                  << std::setw(widths[3]) << std::left << americanOption.NPV()
+                  << std::endl;
+
+        // Monte Carlo Method: MC (crude)
+        // timeSteps = 1;
+        // method = "MC (crude)";
+        // Size mcSeed = 42;
+        // ext::shared_ptr<PricingEngine> mcengine1;
+        // mcengine1 = MakeMCEuropeanEngine<PseudoRandom>(bsmProcess)
+        //     .withSteps(timeSteps)
+        //     .withAbsoluteTolerance(0.02)
+        //     .withSeed(mcSeed);
+        // europeanOption.setPricingEngine(mcengine1);
+        // // Real errorEstimate = europeanOption.errorEstimate();
+        // std::cout << std::setw(widths[0]) << std::left << method
+        //           << std::fixed
+        //           << std::setw(widths[1]) << std::left << europeanOption.NPV()
+        //           << std::setw(widths[2]) << std::left << "N/A"
+        //           << std::setw(widths[3]) << std::left << "N/A"
+        //           << std::endl;
+
+        // Monte Carlo Method: QMC (Sobol)
+        // method = "QMC (Sobol)";
+        // Size nSamples = 32768;  // 2^15
+        //
+        // ext::shared_ptr<PricingEngine> mcengine2;
+        // mcengine2 = MakeMCEuropeanEngine<LowDiscrepancy>(bsmProcess)
+        //     .withSteps(timeSteps)
+        //     .withSamples(nSamples);
+        // europeanOption.setPricingEngine(mcengine2);
+        // std::cout << std::setw(widths[0]) << std::left << method
+        //           << std::fixed
+        //           << std::setw(widths[1]) << std::left << europeanOption.NPV()
+        //           << std::setw(widths[2]) << std::left << "N/A"
+        //           << std::setw(widths[3]) << std::left << "N/A"
+        //           << std::endl;
+
+        // Monte Carlo Method: MC (Longstaff Schwartz)
+        // method = "MC (Longstaff Schwartz)";
+        // ext::shared_ptr<PricingEngine> mcengine3;
+        // mcengine3 = MakeMCAmericanEngine<PseudoRandom>(bsmProcess)
+        //     .withSteps(100)
+        //     .withAntitheticVariate()
+        //     .withCalibrationSamples(4096)
+        //     .withAbsoluteTolerance(0.02)
+        //     .withSeed(mcSeed);
+        // americanOption.setPricingEngine(mcengine3);
+        // std::cout << std::setw(widths[0]) << std::left << method
+        //           << std::fixed
+        //           << std::setw(widths[1]) << std::left << "N/A"
+        //           << std::setw(widths[2]) << std::left << "N/A"
+        //           << std::setw(widths[3]) << std::left << americanOption.NPV()
+        //           << std::endl;
+
+        // End test
+        double seconds = timer.elapsed();
+        Integer hours = int(seconds/3600);
+        seconds -= hours * 3600;
+        Integer minutes = int(seconds/60);
+        seconds -= minutes * 60;
+        std::cout << " \nRun completed in ";
+        if (hours > 0)
+            std::cout << hours << " h ";
+        if (hours > 0 || minutes > 0)
+            std::cout << minutes << " m ";
+        std::cout << std::fixed << std::setprecision(0)
+                  << seconds << " s\n" << std::endl;
         return 0;
 
     } catch (std::exception& e) {
@@ -22,4 +420,3 @@ int main() {
         return 1;
     }
 }
-

--- a/project2/solution/cache.hpp
+++ b/project2/solution/cache.hpp
@@ -1,0 +1,42 @@
+#ifndef quantlib_cache_hpp
+#define quantlib_cache_hpp
+
+#include <ql/functional.hpp>
+#include<tr1/unordered_map>
+
+namespace QuantLib {
+
+    template <typename Key, typename Value>
+    class Cache {
+      public:
+        Cache() {}
+        explicit Cache(const QuantLib::ext::function<Value(Key)> f_) { f = f_;}
+        ~Cache(){ clear();}
+
+        Value operator()(Key key) const {
+            typename std::tr1::unordered_map<Key, Value>::iterator it = memory_map.find(key);
+            if (it != memory_map.end())
+                return it->second;
+            else
+                return put(key);
+        }
+
+        void setf(const QuantLib::ext::function<Value(Key)> f_) { f = f_; }
+
+        void clear() { memory_map.clear(); }
+        void erase(Key key) { memory_map.erase(key); }
+
+      private:
+        QuantLib::ext::function<Value(Key)> f;
+        mutable std::tr1::unordered_map<Key, Value> memory_map;
+
+        Value put(Key key) const {
+            Value value = f(key);
+            memory_map[key] = value;
+            return value;
+        }
+    };
+
+}
+
+#endif

--- a/project2/solution/extendedbinomialtree.cpp
+++ b/project2/solution/extendedbinomialtree.cpp
@@ -1,0 +1,297 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2001, 2002, 2003 Sadruddin Rejeb
+ Copyright (C) 2003 Ferdinando Ametrano
+ Copyright (C) 2005 StatPro Italia srl
+ Copyright (C) 2008 John Maiden
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+// #include <ql/experimental/lattices/extendedbinomialtree.hpp>
+#include "extendedbinomialtree.hpp"
+#include <ql/math/distributions/binomialdistribution.hpp>
+
+namespace QuantLib {
+
+    ExtendedJarrowRudd::ExtendedJarrowRudd(
+                        const ext::shared_ptr<StochasticProcess1D>& process,
+                        Time end, Size steps, Real)
+    : ExtendedEqualProbabilitiesBinomialTree<ExtendedJarrowRudd>(
+                                                        process, end, steps) {
+        // drift removed
+        up_ = process->stdDeviation(0.0, x0_, dt_);
+        upStepByCache.setf(ext::bind(&ExtendedJarrowRudd::upStep, this, _1));
+
+    }
+
+    Real ExtendedJarrowRudd::upStep(Time stepTime) const {
+        return this->treeProcess_->stdDeviation(stepTime, x0_, dt_);
+    }
+
+
+
+    ExtendedCoxRossRubinstein::ExtendedCoxRossRubinstein(
+                        const ext::shared_ptr<StochasticProcess1D>& process,
+                        Time end, Size steps, Real)
+    : ExtendedEqualJumpsBinomialTree<ExtendedCoxRossRubinstein>(
+                                                        process, end, steps) {
+
+        dx_ = process->stdDeviation(0.0, x0_, dt_);
+        pu_ = 0.5 + 0.5*this->driftStepByCache(0.0) / dx_;
+        pd_ = 1.0 - pu_;
+        dxStepByCache.setf(ext::bind(&ExtendedCoxRossRubinstein::dxStep, this, _1));
+        QL_REQUIRE(pu_<=1.0, "negative probability");
+        QL_REQUIRE(pu_>=0.0, "negative probability");
+    }
+
+    Real ExtendedCoxRossRubinstein::dxStep(Time stepTime) const {
+        return this->treeProcess_->stdDeviation(stepTime, x0_, dt_);
+    }
+
+
+    ExtendedAdditiveEQPBinomialTree::ExtendedAdditiveEQPBinomialTree(
+                        const ext::shared_ptr<StochasticProcess1D>& process,
+                        Time end, Size steps, Real)
+    : ExtendedEqualProbabilitiesBinomialTree<ExtendedAdditiveEQPBinomialTree>(
+                                                        process, end, steps) {
+          Real driftStep_ = this->driftStepByCache(0.0);
+          up_ = -0.5 * driftStep_ + 0.5 *
+				      std::sqrt(4.0*process->variance(0.0, x0_, dt_) -
+				          3.0*driftStep_*driftStep_);
+		  upStepByCache.setf(ext::bind(&ExtendedAdditiveEQPBinomialTree::upStep, this, _1));
+
+    }
+
+    Real ExtendedAdditiveEQPBinomialTree::upStep(Time stepTime) const {
+      Real driftStep_ = this->driftStepByCache(stepTime);
+      return (-0.5 * driftStep_ + 0.5 *
+        std::sqrt(4.0*this->treeProcess_->variance(stepTime, x0_, dt_) -
+          3.0*driftStep_*driftStep_));
+    }
+
+
+
+
+    ExtendedTrigeorgis::ExtendedTrigeorgis(
+                        const ext::shared_ptr<StochasticProcess1D>& process,
+                        Time end, Size steps, Real)
+    : ExtendedEqualJumpsBinomialTree<ExtendedTrigeorgis>(process, end, steps) {
+        Real driftStep_ = this->driftStepByCache(0.0);
+        dx_ = std::sqrt(process->variance(0.0, x0_, dt_) +
+            driftStep_*driftStep_);
+        dxStepByCache.setf(ext::bind(&ExtendedTrigeorgis::dxStep, this, _1));
+        pu_ = 0.5 + 0.5*driftStep_ / this->dxStepByCache(0.0);
+
+        pd_ = 1.0 - pu_;
+
+        QL_REQUIRE(pu_<=1.0, "negative probability");
+        QL_REQUIRE(pu_>=0.0, "negative probability");
+    }
+
+    Real ExtendedTrigeorgis::dxStep(Time stepTime) const {
+        Real driftStep_ = this->driftStepByCache(stepTime);
+        return std::sqrt(this->treeProcess_->variance(stepTime, x0_, dt_) +
+			     driftStep_*driftStep_);
+    }
+
+
+    ExtendedTian::ExtendedTian(
+                        const ext::shared_ptr<StochasticProcess1D>& process,
+                        Time end, Size steps, Real)
+    : ExtendedBinomialTree<ExtendedTian>(process, end, steps) {
+
+        Real q = std::exp(process->variance(0.0, x0_, dt_));
+
+        Real r = std::exp(this->driftStepByCache(0.0))*std::sqrt(q);
+
+        up_ = 0.5 * r * q * (q + 1 + std::sqrt(q * q + 2 * q - 3));
+        down_ = 0.5 * r * q * (q + 1 - std::sqrt(q * q + 2 * q - 3));
+
+        pu_ = (r - down_) / (up_ - down_);
+        pd_ = 1.0 - pu_;
+
+        // doesn't work
+        //     treeCentering_ = (up_+down_)/2.0;
+        //     up_ = up_-treeCentering_;
+
+        QL_REQUIRE(pu_<=1.0, "negative probability");
+        QL_REQUIRE(pu_>=0.0, "negative probability");
+    }
+
+    Real ExtendedTian::underlying(Size i, Size index) const {
+        Time stepTime = i*this->dt_;
+        Real q = std::exp(this->treeProcess_->variance(stepTime, x0_, dt_));
+        Real r = std::exp(this->driftStepByCache(stepTime))*std::sqrt(q);
+
+        Real up = 0.5 * r * q * (q + 1 + std::sqrt(q * q + 2 * q - 3));
+        Real down = 0.5 * r * q * (q + 1 - std::sqrt(q * q + 2 * q - 3));
+
+        return x0_ * std::pow(down, Real(BigInteger(i)-BigInteger(index)))
+            * std::pow(up, Real(index));
+    }
+
+    Real ExtendedTian::probability(Size i, Size, Size branch) const {
+        Time stepTime = i*this->dt_;
+        Real q = std::exp(this->treeProcess_->variance(stepTime, x0_, dt_));
+        Real r = std::exp(this->driftStepByCache(stepTime))*std::sqrt(q);
+
+        Real up = 0.5 * r * q * (q + 1 + std::sqrt(q * q + 2 * q - 3));
+        Real down = 0.5 * r * q * (q + 1 - std::sqrt(q * q + 2 * q - 3));
+
+        Real pu = (r - down) / (up - down);
+        Real pd = 1.0 - pu;
+
+        return (branch == 1 ? pu : pd);
+    }
+
+
+
+
+
+    ExtendedLeisenReimer::ExtendedLeisenReimer(
+                        const ext::shared_ptr<StochasticProcess1D>& process,
+                        Time end, Size steps, Real strike)
+    : ExtendedBinomialTree<ExtendedLeisenReimer>(process, end,
+                                                 (steps%2 ? steps : steps+1)),
+      end_(end), oddSteps_(steps%2 ? steps : steps+1), strike_(strike) {
+
+        QL_REQUIRE(strike>0.0, "strike " << strike << "must be positive");
+        Real driftStep_ = this->driftStepByCache(0.0);
+        Real variance = process->variance(0.0, x0_, end);
+
+        Real ermqdt = std::exp(driftStep_ + 0.5*variance / oddSteps_);
+        Real d2 = (std::log(x0_ / strike) + driftStep_*oddSteps_) /
+            std::sqrt(variance);
+
+        pu_ = PeizerPrattMethod2Inversion(d2, oddSteps_);
+        pd_ = 1.0 - pu_;
+        Real pdash = PeizerPrattMethod2Inversion(d2+std::sqrt(variance),
+                                                 oddSteps_);
+        up_ = ermqdt * pdash / pu_;
+        down_ = (ermqdt - pu_ * up_) / (1.0 - pu_);
+
+    }
+
+    Real ExtendedLeisenReimer::underlying(Size i, Size index) const {
+        Time stepTime = i*this->dt_;
+        Real variance = this->treeProcess_->variance(stepTime, x0_, end_);
+
+        Real driftStep_ = this->driftStepByCache(stepTime);
+
+        Real ermqdt = std::exp(driftStep_ + 0.5*variance / oddSteps_);
+		    Real d2 = (std::log(x0_ / strike_) + driftStep_*oddSteps_) /
+			     std::sqrt(variance);
+
+        Real pu = PeizerPrattMethod2Inversion(d2, oddSteps_);
+        Real pdash = PeizerPrattMethod2Inversion(d2+std::sqrt(variance),
+            oddSteps_);
+        Real up = ermqdt * pdash / pu;
+        Real down = (ermqdt - pu * up) / (1.0 - pu);
+
+        return x0_ * std::pow(down, Real(BigInteger(i)-BigInteger(index)))
+            * std::pow(up, Real(index));
+    }
+
+    Real ExtendedLeisenReimer::probability(Size i, Size, Size branch) const {
+        Time stepTime = i*this->dt_;
+        Real variance = this->treeProcess_->variance(stepTime, x0_, end_);
+        Real d2 = (std::log(x0_ / strike_) + this->driftStepByCache(stepTime)*oddSteps_) /
+			std::sqrt(variance);
+
+
+        Real pu = PeizerPrattMethod2Inversion(d2, oddSteps_);
+        Real pd = 1.0 - pu;
+
+        return (branch == 1 ? pu : pd);
+    }
+
+
+
+    Real ExtendedJoshi4::computeUpProb(Real k, Real dj) const {
+        Real alpha = dj/(std::sqrt(8.0));
+        Real alpha2 = alpha*alpha;
+        Real alpha3 = alpha*alpha2;
+        Real alpha5 = alpha3*alpha2;
+        Real alpha7 = alpha5*alpha2;
+        Real beta = -0.375*alpha-alpha3;
+        Real gamma = (5.0/6.0)*alpha5 + (13.0/12.0)*alpha3
+            +(25.0/128.0)*alpha;
+        Real delta = -0.1025 *alpha- 0.9285 *alpha3
+            -1.43 *alpha5 -0.5 *alpha7;
+        Real p =0.5;
+        Real rootk= std::sqrt(k);
+        p+= alpha/rootk;
+        p+= beta /(k*rootk);
+        p+= gamma/(k*k*rootk);
+        // delete next line to get results for j three tree
+        p+= delta/(k*k*k*rootk);
+        return p;
+    }
+
+    ExtendedJoshi4::ExtendedJoshi4(
+                        const ext::shared_ptr<StochasticProcess1D>& process,
+                        Time end, Size steps, Real strike)
+    : ExtendedBinomialTree<ExtendedJoshi4>(process, end,
+                                           (steps%2 ? steps : steps+1)),
+      end_(end), oddSteps_(steps%2 ? steps : steps+1), strike_(strike) {
+
+        QL_REQUIRE(strike>0.0, "strike " << strike << "must be positive");
+        Real variance = process->variance(0.0, x0_, end);
+        Real driftStep_ = this->driftStepByCache(0.0);
+        Real ermqdt = std::exp(driftStep_ + 0.5*variance / oddSteps_);
+		Real d2 = (std::log(x0_ / strike) + driftStep_*oddSteps_) /
+			std::sqrt(variance);
+
+        pu_ = computeUpProb((oddSteps_-1.0)/2.0,d2 );
+        pd_ = 1.0 - pu_;
+        Real pdash = computeUpProb((oddSteps_-1.0)/2.0,d2+std::sqrt(variance));
+        up_ = ermqdt * pdash / pu_;
+        down_ = (ermqdt - pu_ * up_) / (1.0 - pu_);
+    }
+
+    Real ExtendedJoshi4::underlying(Size i, Size index) const {
+        Time stepTime = i*this->dt_;
+        Real variance = this->treeProcess_->variance(stepTime, x0_, end_);
+
+        Real driftStep_ = this->driftStepByCache(stepTime);
+
+        Real ermqdt = std::exp(driftStep_ + 0.5*variance / oddSteps_);
+		Real d2 = (std::log(x0_ / strike_) + driftStep_*oddSteps_) /
+			std::sqrt(variance);
+
+        Real pu = computeUpProb((oddSteps_-1.0)/2.0,d2 );
+        Real pdash = computeUpProb((oddSteps_-1.0)/2.0,d2+std::sqrt(variance));
+        Real up = ermqdt * pdash / pu;
+        Real down = (ermqdt - pu * up) / (1.0 - pu);
+
+        return x0_ * std::pow(down, Real(BigInteger(i)-BigInteger(index)))
+            * std::pow(up, Real(index));
+    }
+
+    Real ExtendedJoshi4::probability(Size i, Size, Size branch) const {
+        Time stepTime = i*this->dt_;
+        Real variance = this->treeProcess_->variance(stepTime, x0_, end_);
+
+        Real d2 = (std::log(x0_ / strike_) + this->driftStepByCache(stepTime)*oddSteps_) /
+			std::sqrt(variance);
+
+        Real pu = computeUpProb((oddSteps_-1.0)/2.0,d2 );
+        Real pd = 1.0 - pu;
+
+        return (branch == 1 ? pu : pd);
+    }
+
+}

--- a/project2/solution/extendedbinomialtree.hpp
+++ b/project2/solution/extendedbinomialtree.hpp
@@ -1,0 +1,261 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2001, 2002, 2003 Sadruddin Rejeb
+ Copyright (C) 2003 Ferdinando Ametrano
+ Copyright (C) 2005 StatPro Italia srl
+ Copyright (C) 2008 John Maiden
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file extendedbinomialtree.hpp
+    \brief Time-dependent binomial tree class
+*/
+
+#ifndef quantlib_extended_binomial_tree_hpp
+#define quantlib_extended_binomial_tree_hpp
+
+#include "cache.hpp"
+#include <ql/instruments/dividendschedule.hpp>
+#include <ql/methods/lattices/tree.hpp>
+#include <ql/stochasticprocess.hpp>
+
+namespace QuantLib {
+
+    //! Binomial tree base class
+    /*! \ingroup lattices */
+    using namespace ext::placeholders;
+
+    template <class T>
+    class ExtendedBinomialTree : public Tree<T> {
+      public:
+        enum Branches { branches = 2 };
+        ExtendedBinomialTree(
+                        const ext::shared_ptr<StochasticProcess1D>& process,
+                        Time end,
+                        Size steps)
+        : Tree<T>(steps+1), treeProcess_(process) {
+            x0_ = process->x0();
+            dt_ = end/steps;
+            driftPerStep_ = process->drift(0.0, x0_) * dt_;
+            driftStepByCache.setf(ext::bind(&ExtendedBinomialTree::driftStep, this, _1));
+
+        }
+        Size size(Size i) const {
+            return i+1;
+        }
+        Size descendant(Size, Size index, Size branch) const {
+            return index + branch;
+        }
+      protected:
+        //time dependent drift per step
+        Real driftStep(Time driftTime) const {
+            return this->treeProcess_->drift(driftTime, x0_) * dt_;
+        }
+        Cache<Time, Real> driftStepByCache;
+        Real x0_, driftPerStep_;
+        Time dt_;
+
+      protected:
+        ext::shared_ptr<StochasticProcess1D> treeProcess_;
+    };
+
+
+    //! Base class for equal probabilities binomial tree
+    /*! \ingroup lattices */
+    template <class T>
+    class ExtendedEqualProbabilitiesBinomialTree
+        : public ExtendedBinomialTree<T> {
+      public:
+        ExtendedEqualProbabilitiesBinomialTree(
+                        const ext::shared_ptr<StochasticProcess1D>& process,
+                        Time end,
+                        Size steps)
+        : ExtendedBinomialTree<T>(process, end, steps) {}
+        virtual ~ExtendedEqualProbabilitiesBinomialTree() {}
+
+        Real underlying(Size i, Size index) const {
+            Time stepTime = i*this->dt_;
+            BigInteger j = 2*BigInteger(index) - BigInteger(i);
+            // exploiting the forward value tree centering
+            return this->x0_*std::exp(i*this->driftStepByCache(stepTime) + j*this->upStepByCache(stepTime));
+
+        }
+
+        Real probability(Size, Size, Size) const { return 0.5; }
+      protected:
+        //the tree dependent up move term at time stepTime
+        virtual Real upStep(Time stepTime) const = 0;
+        Cache<Time, Real> upStepByCache;
+        Real up_;
+    };
+
+
+    //! Base class for equal jumps binomial tree
+    /*! \ingroup lattices */
+    template <class T>
+    class ExtendedEqualJumpsBinomialTree : public ExtendedBinomialTree<T> {
+      public:
+        ExtendedEqualJumpsBinomialTree(
+                        const ext::shared_ptr<StochasticProcess1D>& process,
+                        Time end,
+                        Size steps)
+        : ExtendedBinomialTree<T>(process, end, steps) {
+          probUpByCache.setf(ext::bind(&ExtendedEqualJumpsBinomialTree::probUp, this, _1));
+        }
+        virtual ~ExtendedEqualJumpsBinomialTree() {}
+        Real underlying(Size i, Size index) const {
+            Time stepTime = i*this->dt_;
+            BigInteger j = 2*BigInteger(index) - BigInteger(i);
+            // exploiting equal jump and the x0_ tree centering
+            return this->x0_*std::exp(j*this->dxStepByCache(stepTime));
+
+        }
+
+        Real probability(Size i, Size, Size branch) const {
+            Time stepTime = i*this->dt_;
+            Real upProb = this->probUpByCache(stepTime);
+            Real downProb = 1 - upProb;
+            return (branch == 1 ? upProb : downProb);
+        }
+      protected:
+        //probability of a up move
+        // virtual Real probUp(Time stepTime) const = 0;
+        Real probUp(Time stepTime) const {
+          return 0.5 + 0.5*this->driftStepByCache(stepTime) / this->dxStepByCache(stepTime);
+        }
+        //time dependent term dx_
+        virtual Real dxStep(Time stepTime) const = 0;
+        Cache<Time, Real> probUpByCache;
+        Cache<Time, Real> dxStepByCache;
+
+        Real dx_, pu_, pd_;
+    };
+
+
+    //! Jarrow-Rudd (multiplicative) equal probabilities binomial tree
+    /*! \ingroup lattices */
+    class ExtendedJarrowRudd
+        : public ExtendedEqualProbabilitiesBinomialTree<ExtendedJarrowRudd> {
+      public:
+        ExtendedJarrowRudd(const ext::shared_ptr<StochasticProcess1D>&,
+                           Time end,
+                           Size steps,
+                           Real strike);
+      protected:
+        Real upStep(Time stepTime) const;
+    };
+
+
+    //! Cox-Ross-Rubinstein (multiplicative) equal jumps binomial tree
+    /*! \ingroup lattices */
+    class ExtendedCoxRossRubinstein
+        : public ExtendedEqualJumpsBinomialTree<ExtendedCoxRossRubinstein> {
+      public:
+        ExtendedCoxRossRubinstein(const ext::shared_ptr<StochasticProcess1D>&,
+                                  Time end,
+                                  Size steps,
+                                  Real strike);
+      protected:
+          Real dxStep(Time stepTime) const;
+    };
+
+
+    //! Additive equal probabilities binomial tree
+    /*! \ingroup lattices */
+    class ExtendedAdditiveEQPBinomialTree
+        : public ExtendedEqualProbabilitiesBinomialTree<
+                                            ExtendedAdditiveEQPBinomialTree> {
+      public:
+        ExtendedAdditiveEQPBinomialTree(
+                        const ext::shared_ptr<StochasticProcess1D>&,
+                        Time end,
+                        Size steps,
+                        Real strike);
+
+      protected:
+          Real upStep(Time stepTime) const;
+    };
+
+
+    //! %Trigeorgis (additive equal jumps) binomial tree
+    /*! \ingroup lattices */
+    class ExtendedTrigeorgis
+        : public ExtendedEqualJumpsBinomialTree<ExtendedTrigeorgis> {
+      public:
+        ExtendedTrigeorgis(const ext::shared_ptr<StochasticProcess1D>&,
+                           Time end,
+                           Size steps,
+                           Real strike);
+    protected:
+        Real dxStep(Time stepTime) const;
+    };
+
+
+    //! %Tian tree: third moment matching, multiplicative approach
+    /*! \ingroup lattices */
+    class ExtendedTian : public ExtendedBinomialTree<ExtendedTian> {
+      public:
+        ExtendedTian(const ext::shared_ptr<StochasticProcess1D>&,
+                     Time end,
+                     Size steps,
+                     Real strike);
+
+        Real underlying(Size i, Size index) const;
+        Real probability(Size, Size, Size branch) const;
+      protected:
+        Real up_, down_, pu_, pd_;
+    };
+
+    //! Leisen & Reimer tree: multiplicative approach
+    /*! \ingroup lattices */
+    class ExtendedLeisenReimer
+        : public ExtendedBinomialTree<ExtendedLeisenReimer> {
+      public:
+        ExtendedLeisenReimer(const ext::shared_ptr<StochasticProcess1D>&,
+                             Time end,
+                             Size steps,
+                             Real strike);
+
+        Real underlying(Size i, Size index) const;
+        Real probability(Size, Size, Size branch) const;
+      protected:
+        Time end_;
+        Size oddSteps_;
+        Real strike_, up_, down_, pu_, pd_;
+    };
+
+
+     class ExtendedJoshi4 : public ExtendedBinomialTree<ExtendedJoshi4> {
+      public:
+        ExtendedJoshi4(const ext::shared_ptr<StochasticProcess1D>&,
+                       Time end,
+                       Size steps,
+                       Real strike);
+
+        Real underlying(Size i, Size index) const;
+        Real probability(Size, Size, Size branch) const;
+      protected:
+        Real computeUpProb(Real k, Real dj) const;
+        Time end_;
+        Size oddSteps_;
+        Real strike_, up_, down_, pu_, pd_;
+    };
+
+
+}
+
+
+#endif


### PR DESCRIPTION
This is a draft from group 2. I'm sorry to submit the draft so late. I didn't know about this repository before. It's my fault.

From the beginning, we  work with the latest version of QuantLib from your [main repository](https://github.com/lballabio/QuantLib), and we notice that that version is not compatible with the version you posted here. It is likely because you added the namespace `ext` recently to migrate from C++03 to C++11. Here's our questions:

1. Can we keep working with the latest version or we have to test with the old version? The solution I submitted here is compatible with the latest version of QuantLib (It passes Travis CI)

2. We use an `unordered_map` to cache and the lookup time is O(1). Is is better to try type of cache for better lookup time, LIFO or FIFO for example?

3. 2 last classes in the extended binomial tree, `ExtendedLeisenReimer` and `ExtendedJoshi4` share almost everything except the function to compute probability. Will the performance improves if we make a template class for those 2? That class will be similar to ExtendedEqualProbabilitiesBinomialTree or ExtendedEqualJumpsBinomialTree.

4. 2 functions that are involved with `stepTime` but are not cached yet are `stdDeviation` and `variance`. The reason is because they also have other parameters. Do you know how to cache them?

We're waiting for your answer. Thank you very much.